### PR TITLE
add file header under Apache 2.0 License

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE module PUBLIC
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0"?>
-<!--
-
-    Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <!DOCTYPE module PUBLIC
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -225,6 +208,10 @@
                     <licenseSets>
                         <licenseSet>
                             <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                            <includes>
+                                <include>*.java</include>
+                                <include>src/</include>
+                            </includes>
                             <excludes>
                                 <exclude>**/README</exclude>
                                 <exclude>src/test/resources/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -193,6 +210,31 @@
                         <version>8.29</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>4.6</version>
+                <configuration>
+                    <properties>
+                        <owner>Linked Data Benchmark Council</owner>
+                        <email>info@ldbcouncil.org</email>
+                        <year>2022</year>
+                    </properties>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                            <excludes>
+                                <exclude>**/README</exclude>
+                                <exclude>src/test/resources/**</exclude>
+                                <exclude>src/main/resources/**</exclude>
+                                <exclude>LICENSE.txt</exclude>
+                                <exclude>NOTICE.txt</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/scripts/package-mvn-artifacts.sh
+++ b/scripts/package-mvn-artifacts.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+#
+# Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 set -eu
 set -o pipefail

--- a/scripts/package-mvn-artifacts.sh
+++ b/scripts/package-mvn-artifacts.sh
@@ -1,20 +1,4 @@
 #!/bin/bash
-#
-# Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 
 set -eu
 set -o pipefail

--- a/src/main/java/org/ldbcouncil/finbench/driver/ChildOperationGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/ChildOperationGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public interface ChildOperationGenerator {

--- a/src/main/java/org/ldbcouncil/finbench/driver/Db.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/Db.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/DbConnectionState.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/DbConnectionState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import java.io.Closeable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/DbException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/DbException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public class DbException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/InstantiatingOperationHandlerRunnerFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/InstantiatingOperationHandlerRunnerFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import stormpot.Poolable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/Operation.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/Operation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import java.io.IOException;

--- a/src/main/java/org/ldbcouncil/finbench/driver/OperationException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/OperationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public class OperationException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/OperationHandler.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/OperationHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public interface OperationHandler<OPERATION_TYPE extends Operation,

--- a/src/main/java/org/ldbcouncil/finbench/driver/OperationHandlerRunnableContext.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/OperationHandlerRunnableContext.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/OperationHandlerRunnerFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/OperationHandlerRunnerFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public interface OperationHandlerRunnerFactory {

--- a/src/main/java/org/ldbcouncil/finbench/driver/PoolingOperationHandlerRunnerFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/PoolingOperationHandlerRunnerFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/ResultReporter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/ResultReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/SerializingMarshallingException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/SerializingMarshallingException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public class SerializingMarshallingException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/Workload.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/Workload.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import java.io.Closeable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/WorkloadException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/WorkloadException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 public class WorkloadException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/WorkloadStreams.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/WorkloadStreams.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/constant/OutputFormat.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/constant/OutputFormat.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.constant;
 
 import java.text.DecimalFormat;

--- a/src/main/java/org/ldbcouncil/finbench/driver/control/ConsoleAndFileDriverConfiguration.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/control/ConsoleAndFileDriverConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.control;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/control/ControlService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/control/ControlService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.control;
 
 import org.ldbcouncil.finbench.driver.log.LoggingServiceFactory;

--- a/src/main/java/org/ldbcouncil/finbench/driver/control/DriverConfiguration.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/control/DriverConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.control;
 
 import java.util.Map;

--- a/src/main/java/org/ldbcouncil/finbench/driver/control/DriverConfigurationException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/control/DriverConfigurationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.control;
 
 public class DriverConfigurationException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/control/LocalControlService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/control/LocalControlService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.control;
 
 import org.ldbcouncil.finbench.driver.log.LoggingServiceFactory;

--- a/src/main/java/org/ldbcouncil/finbench/driver/control/OperationMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/control/OperationMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.control;
 
 public enum OperationMode {

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/DuckDbExtractor.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/DuckDbExtractor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv;
 
 import java.io.Closeable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/FileLoader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/FileLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/BufferedCharSeeker.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/BufferedCharSeeker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import static java.lang.Math.max;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharReadable.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharReadable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import java.io.Closeable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharSeeker.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharSeeker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import java.io.Closeable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharSeekerParams.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharSeekerParams.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 public class CharSeekerParams {

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharSeekers.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/CharSeekers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import java.io.FileNotFoundException;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Extractor.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Extractor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 /**

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Extractors.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Extractors.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import static java.lang.reflect.Modifier.isStatic;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Mark.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Mark.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/MultiReadable.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/MultiReadable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import java.io.Closeable;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/RawFunction.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/RawFunction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 /**

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/RawIterator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/RawIterator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Readables.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/Readables.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import java.io.DataInputStream;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/ThreadAheadReadable.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/charseeker/ThreadAheadReadable.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.charseeker;
 
 import static java.lang.Math.min;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/simple/SimpleCsvFileReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/simple/SimpleCsvFileReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.simple;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/csv/simple/SimpleCsvFileWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/csv/simple/SimpleCsvFileWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.csv.simple;
 
 import com.google.common.base.Charsets;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/CalculateWorkloadStatisticsMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/CalculateWorkloadStatisticsMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/CreateValidationParamsMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/CreateValidationParamsMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/Driver.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/Driver.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/DriverException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/DriverException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 public class DriverException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/DriverMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/DriverMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 public interface DriverMode<T> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/ExecuteWorkloadMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/ExecuteWorkloadMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/PrintHelpMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/PrintHelpMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import org.ldbcouncil.finbench.driver.control.ControlService;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/ResultsDirectory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/ResultsDirectory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import static java.util.stream.Collectors.joining;

--- a/src/main/java/org/ldbcouncil/finbench/driver/driver/ValidateDatabaseMode.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/driver/ValidateDatabaseMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.driver;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/formatter/SimpleDetailedWorkloadMetricsFormatter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/formatter/SimpleDetailedWorkloadMetricsFormatter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.formatter;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/ldbcouncil/finbench/driver/formatter/SimpleSummaryWorkloadMetricsFormatter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/formatter/SimpleSummaryWorkloadMetricsFormatter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.formatter;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/ldbcouncil/finbench/driver/formatter/WorkloadMetricsFormatter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/formatter/WorkloadMetricsFormatter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.formatter;
 
 import org.ldbcouncil.finbench.driver.runtime.metrics.WorkloadResultsSnapshot;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/BufferedIterator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/BufferedIterator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/ConstantGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/ConstantGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 public class ConstantGenerator<GENERATE_TYPE> extends Generator<GENERATE_TYPE> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/CsvEventStreamReaderBasicCharSeeker.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/CsvEventStreamReaderBasicCharSeeker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/CsvEventStreamReaderTimedTypedCharSeeker.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/CsvEventStreamReaderTimedTypedCharSeeker.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/CsvEventStreamReaderTimedTypedCsvReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/CsvEventStreamReaderTimedTypedCsvReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/DiscreteGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/DiscreteGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/DiscreteListGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/DiscreteListGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/DynamicRangeUniformNumberGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/DynamicRangeUniformNumberGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import org.apache.commons.math3.random.RandomDataGenerator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/EventStreamReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/EventStreamReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.sql.ResultSet;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/ExponentialNumberGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/ExponentialNumberGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import org.apache.commons.math3.distribution.ExponentialDistribution;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/Generator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/Generator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/GeneratorException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/GeneratorException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 public class GeneratorException extends RuntimeException {

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/GeneratorFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/GeneratorFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/IdentityGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/IdentityGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 public class IdentityGenerator<GENERATE_TYPE> extends Generator<GENERATE_TYPE> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/IncrementingGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/IncrementingGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/InterleaveGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/InterleaveGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/IteratorDereferencingGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/IteratorDereferencingGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/LimitGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/LimitGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/MappingGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/MappingGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/MergingGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/MergingGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/MinMaxGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/MinMaxGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/NaiveBoundedRangeNumberGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/NaiveBoundedRangeNumberGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/NoRemoveIterator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/NoRemoveIterator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/OperationStreamBuffer.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/OperationStreamBuffer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Collections;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/OrderedMultiGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/OrderedMultiGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.ArrayList;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/RandomDataGeneratorFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/RandomDataGeneratorFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import org.apache.commons.math3.random.RandomDataGenerator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/RepeatingGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/RepeatingGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/SizedUniformByteGeneratorGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/SizedUniformByteGeneratorGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/TimeMappingOperationGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/TimeMappingOperationGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/generator/UniformByteGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/generator/UniformByteGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.generator;
 
 import org.apache.commons.math3.random.RandomDataGenerator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/log/Log4jLoggingService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/log/Log4jLoggingService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.log;
 
 import java.text.DecimalFormat;

--- a/src/main/java/org/ldbcouncil/finbench/driver/log/Log4jLoggingServiceFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/log/Log4jLoggingServiceFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.log;
 
 import org.ldbcouncil.finbench.driver.temporal.TemporalUtil;

--- a/src/main/java/org/ldbcouncil/finbench/driver/log/LoggingService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/log/LoggingService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.log;
 
 import org.ldbcouncil.finbench.driver.runtime.metrics.WorkloadResultsSnapshot;

--- a/src/main/java/org/ldbcouncil/finbench/driver/log/LoggingServiceFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/log/LoggingServiceFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.log;
 
 public interface LoggingServiceFactory {

--- a/src/main/java/org/ldbcouncil/finbench/driver/log/RecentThroughputAndDuration.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/log/RecentThroughputAndDuration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.log;
 
 public interface RecentThroughputAndDuration {

--- a/src/main/java/org/ldbcouncil/finbench/driver/result/Path.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/result/Path.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.result;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/src/main/java/org/ldbcouncil/finbench/driver/result/PathDeserializer.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/result/PathDeserializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.result;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/src/main/java/org/ldbcouncil/finbench/driver/result/PathSerializer.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/result/PathSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.result;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/ConcurrentErrorReporter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/ConcurrentErrorReporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/DefaultQueues.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/DefaultQueues.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import java.util.Queue;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/QueueEventFetcher.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/QueueEventFetcher.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import java.util.Queue;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/QueueEventSubmitter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/QueueEventSubmitter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import java.util.Queue;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/SimpleResultsLogWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/SimpleResultsLogWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import java.io.File;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/WorkloadRunner.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/WorkloadRunner.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/WorkloadStatusThread.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/WorkloadStatusThread.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeEvent.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import org.ldbcouncil.finbench.driver.runtime.coordination.ThreadedQueuedCompletionTimeService.CompletionTimeFuture;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 public class CompletionTimeException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 public interface CompletionTimeReader {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeReaderWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeReaderWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 public interface CompletionTimeReaderWriter extends CompletionTimeReader, CompletionTimeWriter {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import java.util.List;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeServiceAssistant.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeServiceAssistant.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import java.util.List;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeStateManager.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeStateManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/CompletionTimeWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 public interface CompletionTimeWriter {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/DummyCompletionTimeWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/DummyCompletionTimeWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 public class DummyCompletionTimeWriter implements CompletionTimeWriter {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/MultiWriterCompletionTimeStateManager.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/MultiWriterCompletionTimeStateManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/MultiWriterCompletionTimeStateManagerWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/MultiWriterCompletionTimeStateManagerWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 public class MultiWriterCompletionTimeStateManagerWriter implements CompletionTimeWriter {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/SynchronizedCompletionTimeService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/SynchronizedCompletionTimeService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import java.util.ArrayList;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/ThreadedQueuedCompletionTimeService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/ThreadedQueuedCompletionTimeService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/ThreadedQueuedCompletionTimeServiceThread.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/coordination/ThreadedQueuedCompletionTimeServiceThread.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.coordination;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/ChildOperationExecutor.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/ChildOperationExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/InitiatedTimeSubmittingOperationRetriever.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/InitiatedTimeSubmittingOperationRetriever.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 import java.util.Iterator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationExecutor.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationExecutorException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationExecutorException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 public class OperationExecutorException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationHandlerRunnableContextRetriever.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationHandlerRunnableContextRetriever.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationStreamExecutorService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationStreamExecutorService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationStreamExecutorServiceThread.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/OperationStreamExecutorServiceThread.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/ThreadPoolOperationExecutor.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/executor/ThreadPoolOperationExecutor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.executor;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ContinuousMetricManager.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ContinuousMetricManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ContinuousMetricSnapshot.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ContinuousMetricSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DiscreteMetricManager.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DiscreteMetricManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import java.util.HashMap;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DiscreteMetricSnapshot.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DiscreteMetricSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorExceptionHandler.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorExceptionHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorSbeMetricsEvent.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorSbeMetricsEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import com.lmax.disruptor.EventFactory;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorSbeMetricsEventHandler.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorSbeMetricsEventHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorSbeMetricsService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/DisruptorSbeMetricsService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/JsonWorkloadMetricsFormatter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/JsonWorkloadMetricsFormatter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import org.ldbcouncil.finbench.driver.formatter.WorkloadMetricsFormatter;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/MetricsCollectionException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/MetricsCollectionException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 public class MetricsCollectionException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/MetricsManager.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/MetricsManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/MetricsService.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/MetricsService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 public interface MetricsService {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/NullResultsLogWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/NullResultsLogWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import java.io.IOException;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/OperationMetricsSnapshot.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/OperationMetricsSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/OperationTypeMetricsManager.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/OperationTypeMetricsManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ResultsLogReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ResultsLogReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ResultsLogWriter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/ResultsLogWriter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import java.io.IOException;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/WorkloadResultsSnapshot.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/WorkloadResultsSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/WorkloadStatusSnapshot.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/WorkloadStatusSnapshot.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 public class WorkloadStatusSnapshot {

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/sbe/MessageHeader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/sbe/MessageHeader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* Generated SBE (Simple Binary Encoding) message codec */
 
 package org.ldbcouncil.finbench.driver.runtime.metrics.sbe;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/sbe/MetaAttribute.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/sbe/MetaAttribute.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* Generated SBE (Simple Binary Encoding) message codec */
 
 package org.ldbcouncil.finbench.driver.runtime.metrics.sbe;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/sbe/MetricsEvent.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/metrics/sbe/MetricsEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* Generated SBE (Simple Binary Encoding) message codec */
 
 package org.ldbcouncil.finbench.driver.runtime.metrics.sbe;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/scheduling/CtDependencyCheck.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/scheduling/CtDependencyCheck.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.scheduling;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/scheduling/Spinner.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/scheduling/Spinner.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.scheduling;
 
 import org.ldbcouncil.finbench.driver.Operation;

--- a/src/main/java/org/ldbcouncil/finbench/driver/runtime/scheduling/SpinnerCheck.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/runtime/scheduling/SpinnerCheck.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.scheduling;
 
 import org.ldbcouncil.finbench.driver.Operation;

--- a/src/main/java/org/ldbcouncil/finbench/driver/statistics/WorkloadStatistics.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/statistics/WorkloadStatistics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.statistics;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/statistics/WorkloadStatisticsCalculator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/statistics/WorkloadStatisticsCalculator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.statistics;
 
 import java.util.ArrayList;

--- a/src/main/java/org/ldbcouncil/finbench/driver/temporal/ManualTimeSource.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/temporal/ManualTimeSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.temporal;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/org/ldbcouncil/finbench/driver/temporal/SystemTimeSource.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/temporal/SystemTimeSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.temporal;
 
 public class SystemTimeSource implements TimeSource {

--- a/src/main/java/org/ldbcouncil/finbench/driver/temporal/TemporalException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/temporal/TemporalException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.temporal;
 
 public class TemporalException extends RuntimeException {

--- a/src/main/java/org/ldbcouncil/finbench/driver/temporal/TemporalUtil.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/temporal/TemporalUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.temporal;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/temporal/TimeSource.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/temporal/TimeSource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.temporal;
 
 public interface TimeSource {

--- a/src/main/java/org/ldbcouncil/finbench/driver/truncation/TruncationOrder.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/truncation/TruncationOrder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.truncation;
 
 public enum TruncationOrder {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Bucket.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Bucket.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import com.google.common.collect.Range;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/ClassLoaderHelper.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/ClassLoaderHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/ClassLoadingException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/ClassLoadingException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public class ClassLoadingException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/DbException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/DbException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public class DbException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/FileUtils.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/FileUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import static java.util.stream.Collectors.joining;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Function0.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Function0.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public interface Function0<RETURN, EXCEPTION extends Exception> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Function1.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Function1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public interface Function1<INPUT, RETURN, EXCEPTION extends Exception> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Function2.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Function2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public interface Function2<INPUT1, INPUT2, RETURN, EXCEPTION extends Exception> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Histogram.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Histogram.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/ListUtils.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/ListUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/MapUtils.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/MapUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/NumberHelper.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/NumberHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public class Tuple {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple2.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public class Tuple2<T1, T2> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple3.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 public class Tuple3<T1, T2, T3> {

--- a/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple4.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/util/Tuple4.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.util;
 
 import java.util.Objects;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/DbValidationResult.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/DbValidationResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/DbValidator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/DbValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationResult.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import java.util.ArrayList;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationSummary.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationSummary.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationSummaryCalculator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationSummaryCalculator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import java.util.HashMap;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationTolerances.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidationTolerances.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 /**

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ResultsLogValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationEquality.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationEquality.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import java.math.RoundingMode;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationException.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 public class ValidationException extends Exception {

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParam.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParam.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamDeserializer.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamDeserializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamSerializer.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsFromCsvRows.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsFromCsvRows.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsFromJson.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsFromJson.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsToCsvRows.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsToCsvRows.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsToJson.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/validation/ValidationParamsToJson.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.validation;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/ClassNameWorkloadFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/ClassNameWorkloadFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/WorkloadFactory.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/WorkloadFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads;
 
 import org.ldbcouncil.finbench.driver.Workload;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/simple/SimpleWorkload.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/simple/SimpleWorkload.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.simple;
 
 import java.io.IOException;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/simple/db/SimpleDb.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/simple/db/SimpleDb.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.simple.db;
 
 public class SimpleDb {

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/BatchedOperationStreamReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/BatchedOperationStreamReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import java.io.File;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchSimpleReadGenerator.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchSimpleReadGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchTransactionDbValidationParametersFilter.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchTransactionDbValidationParametersFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import java.util.ArrayList;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchTransactionWorkload.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchTransactionWorkload.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchTransactionWorkloadConfiguration.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcFinBenchTransactionWorkloadConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcNoResult.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcNoResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcNoResultJsonSerializer.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcNoResultJsonSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import com.fasterxml.jackson.core.JsonGenerator;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcOperation.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/LdbcOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static com.fasterxml.jackson.annotation.JsonTypeInfo.As;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/OperationStreamReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/OperationStreamReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import java.io.File;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/QueryEventStreamReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/QueryEventStreamReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/RunnableOperationStreamBatchLoader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/RunnableOperationStreamBatchLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import java.io.File;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/UpdateEventStreamReader.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/UpdateEventStreamReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static java.lang.String.format;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/db/DummyLdbcFinBenchTransactionDb.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/db/DummyLdbcFinBenchTransactionDb.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.db;
 
 public class DummyLdbcFinBenchTransactionDb {

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead1.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 1:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead10.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead10.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 10:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead10Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead10Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead11.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead11.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 11:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead11Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead11Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead12.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead12.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 12:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead12Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead12Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead1Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead1Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead2.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 2:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead2Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead2Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead3.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 3:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead3Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead3Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead4.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead4.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 4:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead4Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead4Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead5.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead5.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 5:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead5Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead5Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead6.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead6.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 6:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead6Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead6Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead7.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead7.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 7:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead7Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead7Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead8.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead8.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 8:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead8Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead8Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead9.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead9.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload complex read query 9:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead9Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ComplexRead9Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ReadWrite1.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ReadWrite1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload read write query 1:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ReadWrite2.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ReadWrite2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload read write query 2:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ReadWrite3.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/ReadWrite3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload read write query 3:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead1.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload simple read query 1:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead1Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead1Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead2.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload simple read query 2:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead2Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead2Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead3.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload simple read query 3:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead3Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead3Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead4.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead4.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload simple read query 4:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead4Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead4Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead5.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead5.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload simple read query 5:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead5Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead5Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead6.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead6.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload simple read query 6:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead6Result.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/SimpleRead6Result.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write1.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 1:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write10.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write10.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 10:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write11.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write11.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 11:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write12.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write12.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 12:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write13.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write13.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 13:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write14.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write14.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 14:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write15.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write15.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 15:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write16.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write16.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 16:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write17.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write17.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 17:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write18.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write18.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 18:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write19.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write19.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 19:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write2.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 2:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write3.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 3:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write4.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write4.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 4:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write5.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write5.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 5:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write6.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write6.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 6:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write7.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write7.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 7:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write8.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write8.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 8:

--- a/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write9.java
+++ b/src/main/java/org/ldbcouncil/finbench/driver/workloads/transaction/queries/Write9.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction.queries;
 /*
  * Transaction workload write query 9:

--- a/src/main/java/org/ldbcouncil/finbench/impls/dummy/DummyDb.java
+++ b/src/main/java/org/ldbcouncil/finbench/impls/dummy/DummyDb.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.impls.dummy;
 
 import java.io.IOException;

--- a/src/main/java/org/ldbcouncil/finbench/impls/dummy/DummyDbConnectionState.java
+++ b/src/main/java/org/ldbcouncil/finbench/impls/dummy/DummyDbConnectionState.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.impls.dummy;
 
 import java.io.IOException;

--- a/src/test/java/org/ldbcouncil/finbench/driver/runtime/metrics/DummyCountingMetricsService.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/runtime/metrics/DummyCountingMetricsService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.runtime.metrics;
 
 import java.util.HashMap;

--- a/src/test/java/org/ldbcouncil/finbench/driver/testutils/TestUtils.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/testutils/TestUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.testutils;
 
 import static java.lang.String.format;

--- a/src/test/java/org/ldbcouncil/finbench/driver/testutils/ThreadPoolLoadGenerator.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/testutils/ThreadPoolLoadGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.testutils;
 
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/OperationHandlerRunnableContextFactoryTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/OperationHandlerRunnableContextFactoryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads;
 
 import static java.lang.String.format;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/WorkloadStreamsTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/WorkloadStreamsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads;
 
 import static org.hamcrest.CoreMatchers.anyOf;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyDb.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyDb.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import java.io.IOException;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyResult.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 public class DummyResult {

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyWorkload.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyWorkload.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import java.util.Collections;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyWorkloadFactory.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/DummyWorkloadFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import com.google.common.collect.Lists;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/NothingOperation.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/NothingOperation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/NothingOperationFactory.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/NothingOperationFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/NothingOperationHandler.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/NothingOperationHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation1.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation1.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation1Factory.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation1Factory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import java.util.Iterator;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation2.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation2Factory.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation2Factory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import java.util.Iterator;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation3.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation3.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation3Factory.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/dummy/TimedNamedOperation3Factory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.dummy;
 
 import java.util.Iterator;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionQueryEqualityTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionQueryEqualityTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionQueryResultEqualityTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionQueryResultEqualityTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionReadEventStreamReaderTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionReadEventStreamReaderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionSimpleReadGeneratorTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionSimpleReadGeneratorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionUpdateEventStreamReaderTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionUpdateEventStreamReaderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionWorkloadTest.java
+++ b/src/test/java/org/ldbcouncil/finbench/driver/workloads/transaction/TransactionWorkloadTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2022 Linked Data Benchmark Council (info@ldbcouncil.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.ldbcouncil.finbench.driver.workloads.transaction;
 
 public class TransactionWorkloadTest {


### PR DESCRIPTION
Add Apache 2.0 License header to every original source document (code and documentation, but not the LICENSE and NOTICE files)